### PR TITLE
fix: remove seeded default users

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -17,17 +16,5 @@ class DatabaseSeeder extends Seeder
             SettingSeeder::class,
             RolePermissionSeeder::class,
         ]);
-
-        $superadmin = User::factory()->create([
-            'name' => 'Super Admin',
-            'email' => 'admin@example.com',
-        ]);
-        $superadmin->assignRole('superadmin');
-
-        $user = User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
-        $user->assignRole('user');
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent creation of a predictable privileged account during `php artisan db:seed` by removing seeded demo users so setup does not ship a known superadmin credential.

### Description
- Deleted the code that created the `Super Admin` and `Test User` entries from `database/seeders/DatabaseSeeder.php` so the seeder now only runs `SettingSeeder` and `RolePermissionSeeder`.
- Removed the now-unused `App\Models\User` import from `DatabaseSeeder.php` as part of the cleanup.

### Testing
- Ran `php -l database/seeders/DatabaseSeeder.php` which reported no syntax errors.
- Attempted `php artisan test` but it was skipped in this environment because `vendor/autoload.php` is missing, so the test suite could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba210911d48330a5cf9378e9e1e7e7)